### PR TITLE
feat: manual refresh button to LeaderBoard

### DIFF
--- a/client/src/LeaderBoard.jsx
+++ b/client/src/LeaderBoard.jsx
@@ -9,30 +9,28 @@ function LeaderBoard() {
   const [loading, setLoading] = useState(true);
   const [lastRefreshed, setLastRefreshed] = useState(null);
 
-  const fetchLeaderboard = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const response = await axios.get('/api/leaderboard');
-      if (Array.isArray(response.data)) {
-        setLeaderboard(response.data);
-        setLastRefreshed(new Date());
-      } else {
-        throw new Error('Unexpected response format');
-      }
-    } catch (err) {
-      console.error('Error fetching leaderboard:', err);
-      const message =
-        err.response?.data?.error || 'Failed to fetch leaderboard.';
-      setError(message);
-    } finally {
-      setLoading(false);
-    }
-  };
-
   useEffect(() => {
+    const fetchLeaderboard = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await axios.get('/api/leaderboard');
+        if (Array.isArray(response.data)) {
+          setLeaderboard(response.data);
+          setLastRefreshed(new Date());
+        } else {
+          throw new Error('Unexpected response format');
+        }
+      } catch (err) {
+        console.error('Error fetching leaderboard:', err);
+        const message =
+          err.response?.data?.error || 'Failed to fetch leaderboard.';
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    };
     fetchLeaderboard();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   function formatDate(date) {
@@ -69,18 +67,8 @@ function LeaderBoard() {
           <p className='text-center text-gray-400'>No data available.</p>
         ) : (
           <>
-            <div className='flex flex-col md:flex-row items-center justify-center gap-4 text-sm text-gray-400 text-center mb-4'>
-              <span>
-                Last Refreshed: {lastRefreshed ? formatDate(lastRefreshed) : 'N/A'}
-              </span>
-              <button
-                className='px-4 py-2 bg-blue-500 text-white rounded-lg font-bold hover:bg-blue-600 transition text-sm mt-2 md:mt-0'
-                onClick={fetchLeaderboard}
-                disabled={loading}
-                aria-label='Refresh Leaderboard'
-              >
-                {loading ? 'Refreshing...' : 'Refresh'}
-              </button>
+            <div className='text-sm text-gray-400 text-center mb-4'>
+              Last Refreshed: {lastRefreshed ? formatDate(lastRefreshed) : 'N/A'}
             </div>
             <div className='overflow-y-auto max-h-[700px]'>
               <table className='w-full text-center border-collapse border border-gray-800 rounded-t-xl overflow-hidden'>

--- a/client/src/LeaderBoard.jsx
+++ b/client/src/LeaderBoard.jsx
@@ -9,27 +9,29 @@ function LeaderBoard() {
   const [loading, setLoading] = useState(true);
   const [lastRefreshed, setLastRefreshed] = useState(null);
 
-  useEffect(() => {
-    const fetchLeaderboard = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const response = await axios.get('/api/leaderboard');
-        if (Array.isArray(response.data)) {
-          setLeaderboard(response.data);
-          setLastRefreshed(new Date());
-        } else {
-          throw new Error('Unexpected response format');
-        }
-      } catch (err) {
-        console.error('Error fetching leaderboard:', err);
-        const message =
-          err.response?.data?.error || 'Failed to fetch leaderboard.';
-        setError(message);
-      } finally {
-        setLoading(false);
+  // Fetch leaderboard function for both mount and manual refresh
+  const fetchLeaderboard = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await axios.get('/api/leaderboard');
+      if (Array.isArray(response.data)) {
+        setLeaderboard(response.data);
+        setLastRefreshed(new Date());
+      } else {
+        throw new Error('Unexpected response format');
       }
-    };
+    } catch (err) {
+      console.error('Error fetching leaderboard:', err);
+      const message =
+        err.response?.data?.error || 'Failed to fetch leaderboard.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
     fetchLeaderboard();
   }, []);
 
@@ -53,6 +55,24 @@ function LeaderBoard() {
           Leaderboard
         </h2>
 
+        {/* Manual Refresh Button */}
+        <div className='flex justify-center mb-4'>
+          <button
+            onClick={fetchLeaderboard}
+            className={`flex items-center px-6 py-2 rounded bg-blue-600 hover:bg-blue-700 text-white font-semibold shadow-md transition-colors duration-200 disabled:opacity-60 disabled:cursor-not-allowed`}
+            disabled={loading}
+            aria-label='Refresh Leaderboard'
+          >
+            {loading ? (
+              <>
+                <FaSpinner className='animate-spin mr-2' />
+                Refreshing...
+              </>
+            ) : (
+              'Refresh'
+            )}
+          </button>
+        </div>
         {loading ? (
           <div className='flex justify-center items-center space-x-4'>
             <FaSpinner className='animate-spin text-4xl text-blue-400' />
@@ -98,7 +118,7 @@ function LeaderBoard() {
                   {leaderboard.map((player, index) => (
                     <tr
                       key={player.username}
-                      className={`${
+                      className={`$
                         index % 2 === 0 ? 'bg-gray-600' : 'bg-gray-500'
                       } border-t border-gray-300`}
                     >

--- a/client/src/LeaderBoard.jsx
+++ b/client/src/LeaderBoard.jsx
@@ -2,38 +2,37 @@ import { useState, useEffect } from 'react';
 import axios from 'axios';
 import { FaSpinner, FaExclamationTriangle } from 'react-icons/fa';
 
+
 function LeaderBoard() {
   const [leaderboard, setLeaderboard] = useState([]);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
   const [lastRefreshed, setLastRefreshed] = useState(null);
 
-  useEffect(() => {
-    const fetchLeaderboard = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const response = await axios.get('/api/leaderboard');
-
-        // console.log('Leaderboard Data:', response.data);
-
-        if (Array.isArray(response.data)) {
-          setLeaderboard(response.data);
-          setLastRefreshed(new Date());
-        } else {
-          throw new Error('Unexpected response format');
-        }
-      } catch (err) {
-        console.error('Error fetching leaderboard:', err);
-        const message =
-          err.response?.data?.error || 'Failed to fetch leaderboard.';
-        setError(message);
-      } finally {
-        setLoading(false);
+  const fetchLeaderboard = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await axios.get('/api/leaderboard');
+      if (Array.isArray(response.data)) {
+        setLeaderboard(response.data);
+        setLastRefreshed(new Date());
+      } else {
+        throw new Error('Unexpected response format');
       }
-    };
+    } catch (err) {
+      console.error('Error fetching leaderboard:', err);
+      const message =
+        err.response?.data?.error || 'Failed to fetch leaderboard.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
 
+  useEffect(() => {
     fetchLeaderboard();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   function formatDate(date) {
@@ -70,9 +69,18 @@ function LeaderBoard() {
           <p className='text-center text-gray-400'>No data available.</p>
         ) : (
           <>
-            <div className='text-sm text-gray-400 text-center mb-4'>
-              Last Refreshed:{' '}
-              {lastRefreshed ? formatDate(lastRefreshed) : 'N/A'}
+            <div className='flex flex-col md:flex-row items-center justify-center gap-4 text-sm text-gray-400 text-center mb-4'>
+              <span>
+                Last Refreshed: {lastRefreshed ? formatDate(lastRefreshed) : 'N/A'}
+              </span>
+              <button
+                className='px-4 py-2 bg-blue-500 text-white rounded-lg font-bold hover:bg-blue-600 transition text-sm mt-2 md:mt-0'
+                onClick={fetchLeaderboard}
+                disabled={loading}
+                aria-label='Refresh Leaderboard'
+              >
+                {loading ? 'Refreshing...' : 'Refresh'}
+              </button>
             </div>
             <div className='overflow-y-auto max-h-[700px]'>
               <table className='w-full text-center border-collapse border border-gray-800 rounded-t-xl overflow-hidden'>


### PR DESCRIPTION
This PR adds a manual "Refresh" button to the Leaderboard page. The button allows users to reload the leaderboard data on demand. It is styled in blue, shows a loading spinner and disables itself while data is being fetched. Error handling and loading states are preserved for a smooth user experience.

Key Changes
Added a blue "Refresh" button above the leaderboard table.
Button is disabled and shows a spinner while loading.
Leaderboard data and last refreshed time update on button click.
