### PR TITLE
Add Reset Button to Clear Query Input and Results Panel

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,3 +1,8 @@
+@keyframes resetPulse {
+  0% { box-shadow: 0 0 0 0 #fbbf24; }
+  70% { box-shadow: 0 0 0 8px #fbbf2433; }
+  100% { box-shadow: 0 0 0 0 #fbbf2400; }
+}
 #root {
   max-width: 1280px;
   margin: 0 auto;

--- a/client/src/Home.jsx
+++ b/client/src/Home.jsx
@@ -191,6 +191,18 @@ function Home() {
     return <Navigate to='/countdown' replace />;
   }
 
+  // Reset handler for the Reset button
+  const handleReset = () => {
+    setUserQuery("");
+    setQueryResult(null);
+    setError(null);
+    setSqlError(null);
+    setLoading(false);
+    if (problemId) {
+      localStorage.setItem(`userQuery_${problemId}`, "");
+    }
+  };
+
   return (
     <div className='flex flex-col h-screen'>
       <Header userInfo={userInfo} />
@@ -209,6 +221,7 @@ function Home() {
             setUserQuery={handleSetUserQuery}
             handleEvaluate={handleEvaluate}
             loading={loading}
+            handleReset={handleReset}
           />
           <ErrorDisplay error={error} sqlError={sqlError} />
           <QueryResult queryResult={queryResult} />

--- a/client/src/components/QueryEditor.jsx
+++ b/client/src/components/QueryEditor.jsx
@@ -1,13 +1,24 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import Editor from "@monaco-editor/react";
 import { ClipLoader } from "react-spinners";
 import PropTypes from "prop-types";
 
-const QueryEditor = ({ userQuery, setUserQuery, handleEvaluate, loading }) => {
+import { RotateCcw } from "lucide-react";
+
+const QueryEditor = ({ userQuery, setUserQuery, handleEvaluate, loading, handleReset }) => {
+  const resetBtnRef = useRef(null);
   useEffect(() => {
     const handleKeyDown = (event) => {
+      // Ctrl+Enter for Evaluate
       if (event.ctrlKey && event.key === 'Enter') {
         handleEvaluate();
+      }
+      // Ctrl+Shift+R for Reset
+      if (event.ctrlKey && event.shiftKey && (event.key === 'r' || event.key === 'R')) {
+        if (resetBtnRef.current) {
+          resetBtnRef.current.focus();
+        }
+        handleReset();
       }
     };
 
@@ -15,7 +26,7 @@ const QueryEditor = ({ userQuery, setUserQuery, handleEvaluate, loading }) => {
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [handleEvaluate]);
+  }, [handleEvaluate, handleReset]);
 
   return (
     <div>
@@ -42,31 +53,62 @@ const QueryEditor = ({ userQuery, setUserQuery, handleEvaluate, loading }) => {
       </div>
 
       <div className='flex flex-col items-end justify-end mt-4'>
-        <button
-          onClick={handleEvaluate}
-          disabled={loading}
-          className={`px-6 py-2 me-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 font-semibold ${
-            loading ? 'opacity-50 cursor-not-allowed' : ''
-          }`}
-        >
-          {loading ? (
-            <div className='flex justify-center items-center'>
-              <ClipLoader
-                color='#fff'
-                loading={loading}
-                size={20}
-                className='mr-2'
-              />
-              Evaluating...
-            </div>
-          ) : (
-            'Evaluate'
-          )}
-        </button>
+        <div className='flex gap-2 group'>
+          <button
+            onClick={handleEvaluate}
+            disabled={loading}
+            className={`px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 font-semibold transition-all duration-150 shadow-sm ${
+              loading ? 'opacity-50 cursor-not-allowed' : ''
+            }`}
+            aria-label="Run Query (Ctrl+Enter)"
+          >
+            {loading ? (
+              <div className='flex justify-center items-center'>
+                <ClipLoader
+                  color='#fff'
+                  loading={loading}
+                  size={20}
+                  className='mr-2'
+                />
+                Evaluating...
+              </div>
+            ) : (
+              <span className="flex items-center gap-2">
+                <span>Evaluate</span>
+                <kbd className="ml-1 px-1 py-0.5 text-xs bg-blue-800/60 rounded">Ctrl+Enter</kbd>
+              </span>
+            )}
+          </button>
+          <button
+            ref={resetBtnRef}
+            onClick={handleReset}
+            disabled={loading}
+            className={`px-6 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 font-semibold flex items-center gap-2 transition-all duration-150 shadow-sm group/reset-btn ${
+              loading ? 'opacity-50 cursor-not-allowed' : ''
+            }`}
+            aria-label="Reset Query and Results (Ctrl+Shift+R)"
+            tabIndex={0}
+            title="Reset editor, results, and errors (Ctrl+Shift+R)"
+            style={{animation: 'none'}}
+            onMouseDown={e => {
+              // Add a quick animation on click
+              e.currentTarget.style.animation = 'resetPulse 0.3s';
+            }}
+            onAnimationEnd={e => {
+              e.currentTarget.style.animation = 'none';
+            }}
+          >
+            <RotateCcw className="w-4 h-4" />
+            <span>Reset</span>
+            <kbd className="ml-1 px-1 py-0.5 text-xs bg-gray-800/60 rounded hidden md:inline">Ctrl+Shift+R</kbd>
+          </button>
+        </div>
         <p className='text-gray-200 my-2 text-sm'>
-          Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to execute.
+          <span>Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to execute. </span>
+          <span className="ml-2">Press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>R</kbd> to reset.</span>
         </p>
       </div>
+// Animation for reset button is now in App.css
     </div>
   );
 };
@@ -76,6 +118,7 @@ QueryEditor.propTypes = {
   setUserQuery: PropTypes.func.isRequired,
   handleEvaluate: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired,
+  handleReset: PropTypes.func.isRequired,
 };
 
 export default QueryEditor;


### PR DESCRIPTION
## [Enhancement] Add Reset Button to Clear Query Input and Results Panel (#37)

### Summary
This PR adds a **Reset** button to the SQL editor interface, allowing users to quickly clear the query input field and reset the results panel in a single click.

### What's Changed
- Added a **Reset** button placed next to the **Run/Execute** button for easy access.
- On click, the button:
  - Clears the SQL query editor text area.
  - Removes any displayed results in the results panel.
  - Resets error messages and loading states.
- Updated component state handling to ensure both query input and results are fully cleared.
- Applied styling consistent with the existing UI buttons for a seamless look.

### How It Works
- Uses existing state management for query text and results.
- Resets relevant states to their initial values on button click.
- Ensures no lingering error or loading indicators remain after reset.

### Benefits
- **Improved Usability** – Users can start fresh without manually deleting text and results.
- **Faster Workflow** – Ideal for users testing multiple queries or beginners learning SQL.
- **Cleaner Interface** – Prevents clutter from old query results.

### Related Issue
Closes #37

---
✅ I have read the Contributing Guidelines  
⭐ I have starred the repository  
🚀 I am a GSS
