### PR TITLE
Enhance mysql to sqlite parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
     "dev:client": "cd client && npm run dev",
     "build": "cd client && npm run build",
     "start": "cd server && npm start",
-    "install:all": "npm install"
+    "install:all": "npm install",
+    "test": "jest"
   },
   "devDependencies": {
-    "concurrently": "^8.2.2"
+    "concurrently": "^8.2.2",
+    "jest": "^30.1.1"
   },
   "dependencies": {
     "mysql2": "^3.14.3"

--- a/server/tests/mysqlToSQLiteParser.test.js
+++ b/server/tests/mysqlToSQLiteParser.test.js
@@ -1,0 +1,59 @@
+const mysqlToSQLiteParser = require("../utils/mysqlToSQLiteParser"); 
+
+describe("mysqlToSQLiteParser", () => {
+
+  test("converts NOW() to CURRENT_TIMESTAMP", () => {
+    expect(mysqlToSQLiteParser("SELECT NOW();")).toBe("SELECT CURRENT_TIMESTAMP;");
+  });
+
+  test("converts CURDATE() to DATE('now')", () => {
+    expect(mysqlToSQLiteParser("SELECT CURDATE();")).toBe("SELECT DATE('now');");
+  });
+
+  test("converts DATE_ADD with interval days", () => {
+    expect(mysqlToSQLiteParser("SELECT DATE_ADD('2023-01-01', INTERVAL 7 DAY);"))
+      .toBe("SELECT DATE('2023-01-01', '+7 day');");
+  });
+
+  test("converts DATE_SUB with interval days", () => {
+    expect(mysqlToSQLiteParser("SELECT DATE_SUB('2023-01-01', INTERVAL 3 DAY);"))
+      .toBe("SELECT DATE('2023-01-01', '-3 day');");
+  });
+
+  test("converts CONCAT into || operator", () => {
+    expect(mysqlToSQLiteParser("SELECT CONCAT(first, ' ', last) FROM users;"))
+      .toBe("SELECT first || ' ' || last FROM users;");
+  });
+
+  test("converts SUBSTRING to SUBSTR", () => {
+    expect(mysqlToSQLiteParser("SELECT SUBSTRING(name, 2, 3) FROM users;"))
+      .toBe("SELECT SUBSTR(name, 2, 3) FROM users;");
+  });
+
+  test("converts LEFT to SUBSTR", () => {
+    expect(mysqlToSQLiteParser("SELECT LEFT(name, 4) FROM users;"))
+      .toBe("SELECT SUBSTR(name, 1, 4) FROM users;");
+  });
+
+  test("converts RIGHT to SUBSTR with negative index", () => {
+    expect(mysqlToSQLiteParser("SELECT RIGHT(name, 2) FROM users;"))
+      .toBe("SELECT SUBSTR(name, -2) FROM users;");
+  });
+
+  // ---- Aggregate/Null handling ----
+  test("converts IFNULL to COALESCE", () => {
+    expect(mysqlToSQLiteParser("SELECT IFNULL(age, 0) FROM users;"))
+      .toBe("SELECT COALESCE(age, 0) FROM users;");
+  });
+
+  test("converts AUTO_INCREMENT to AUTOINCREMENT", () => {
+    expect(mysqlToSQLiteParser("id INT PRIMARY KEY AUTO_INCREMENT;"))
+      .toBe("id INT PRIMARY KEY AUTOINCREMENT;");
+  });
+
+  test("removes ENGINE and DEFAULT CHARSET", () => {
+    expect(
+      mysqlToSQLiteParser("CREATE TABLE t (id INT) ENGINE=InnoDB DEFAULT CHARSET=utf8;")
+    ).toBe("CREATE TABLE t (id INT);");
+  });
+});

--- a/server/utils/mysqlToSQLiteParser.js
+++ b/server/utils/mysqlToSQLiteParser.js
@@ -1,5 +1,46 @@
-// Converts MySQL queries to SQLite-compatible syntax
 module.exports = function mysqlToSQLiteParser(query) {
-  // Implement your conversion logic here
-  return query;
+  if (!query || typeof query !== "string") return query;
+  let q = query;
+
+  q = q.replace(/\bNOW\(\)/gi, "CURRENT_TIMESTAMP");
+  q = q.replace(/\bCURDATE\(\)/gi, "DATE('now')");
+  q = q.replace(/\bCURTIME\(\)/gi, "TIME('now')");
+  q = q.replace(/\bUTC_DATE\(\)/gi, "DATE('now')");
+  q = q.replace(/\bUTC_TIME\(\)/gi, "TIME('now')");
+
+  q = q.replace(
+    /DATE_ADD\(([^,]+),\s*INTERVAL\s+(\d+)\s+DAY\)/gi,
+    "DATE($1, '+$2 day')"
+  );
+
+  q = q.replace(
+    /DATE_SUB\(([^,]+),\s*INTERVAL\s+(\d+)\s+DAY\)/gi,
+    "DATE($1, '-$2 day')"
+  );
+
+  q = q.replace(/\bCONCAT\(([^)]+)\)/gi, (match, args) => {
+    return args.split(",").map(a => a.trim()).join(" || ");
+  });
+
+
+  q = q.replace(
+    /\bSUBSTRING\(([^,]+),\s*([^,]+),\s*([^)]+)\)/gi,
+    "SUBSTR($1, $2, $3)"
+  );
+
+  q = q.replace(/\bLEFT\(([^,]+),\s*([^)]+)\)/gi, "SUBSTR($1, 1, $2)");
+
+  q = q.replace(/\bRIGHT\(([^,]+),\s*([^)]+)\)/gi, "SUBSTR($1, -$2)");
+
+  q = q.replace(/\bLENGTH\(/gi, "LENGTH(");
+
+  q = q.replace(/\bIFNULL\(/gi, "COALESCE(");
+
+  q = q.replace(/\bAUTO_INCREMENT\b/gi, "AUTOINCREMENT");
+
+  q = q.replace(/ENGINE=\w+\s*/gi, "");
+  q = q.replace(/DEFAULT CHARSET=\w+\s*/gi, "");
+
+  q = q.replace(/\s*;/g, ";");  
+  return q.trim();
 };


### PR DESCRIPTION
Fixes #21 
The current mysqlToSQLiteParser.js only returns the input query without handling MySQL-specific syntax. This limits the ability to run MySQL queries directly on SQLite during problem evaluation. This enhancement implements robust translation logic to handle commonly used MySQL functions, schema definitions, and syntax differences, ensuring wider compatibility and preventing query failures.

## Changes Implemented
- Date/Time Functions
- String Functions
- Aggregate / Null Handling
- Schema Compatibility
- Cleanup

## Test Added
Added mysqlToSQLiteParser.test.js with 11 test cases covering.

##Screenshot
<img width="514" height="456" alt="Screenshot 2025-08-31 173625" src="https://github.com/user-attachments/assets/a2774cee-92ad-4db1-b779-ab9cd2b4bd08" />
